### PR TITLE
Add github statuses to build, deploy and test jobs

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -103,6 +103,27 @@ resources:
     access_key_id: ((aws-access-key))
     secret_access_key: ((aws-secret-access-key))
 
+- name: "build-status"
+  type: "github-status"
+  source:
+    repository: 10gen/ops-manager-cloudfoundry
+    access_token: ((repo-github-token))
+    context: build-tile
+
+- name: "deploy-status"
+  type: "github-status"
+  source:
+    repository: 10gen/ops-manager-cloudfoundry
+    access_token: ((repo-github-token))
+    context: deploy-tile
+
+- name: "test-status"
+  type: "github-status"
+  source:
+    repository: 10gen/ops-manager-cloudfoundry
+    access_token: ((repo-github-token))
+    context: smoke-tests
+
 resource_types:
 - name: pivnet
   type: docker-image
@@ -113,6 +134,11 @@ resource_types:
   type: docker-image
   source:
     repository: cfcommunity/slack-notification-resource
+- name: "github-status"
+  type: "docker-image"
+  source:
+    repository: "dpb587/github-status-resource"
+    tag: "master"
 
 jobs:
 - name: build-tile
@@ -140,8 +166,28 @@ jobs:
     - get: version
       params:
         pre: rc
+  - put: "build-status"
+    params:
+      state: "pending"
+      commit: "ops-manager-cloudfoundry"
   - task: build-tile
     file: ops-manager-cloudfoundry/ci/tasks/build-tile/task.yml
+    on_failure:
+      put: "build-status"
+      params:
+        state: "failure"
+        commit: "ops-manager-cloudfoundry"
+    on_error:
+      put: "build-status"
+      params:
+        state: "error"
+        commit: "ops-manager-cloudfoundry"
+    on_abort:
+      put: "build-status"
+      params:
+        state: "error"
+        commit: "ops-manager-cloudfoundry"
+        description: aborted
     params:
       AWS_KEY: ((aws-access-key))
       AWS_SECRET_KEY: ((aws-secret-access-key))
@@ -151,6 +197,10 @@ jobs:
   - put: version
     params:
       pre: rc
+  - put: "build-status"
+    params:
+      state: "success"
+      commit: "ops-manager-cloudfoundry"
 
 - name: deploy-tile
   serial: true
@@ -167,6 +217,10 @@ jobs:
     - get: stemcell
       params:
         globs: ["*azure*"]
+  - put: "deploy-status"
+    params:
+      state: "pending"
+      commit: "ops-manager-cloudfoundry"
   - task: deploy-tile
     file: ops-manager-cloudfoundry/ci/tasks/deploy-tile/task.yml
     params:
@@ -177,6 +231,26 @@ jobs:
       PRODUCT_PROPERTIES: ((product_properties))
       PRODUCT_NETWORK_AZS: ((product_network_azs))
       CONFIG: config
+      on_failure:
+        put: "deploy-status"
+        params:
+          state: "failure"
+          commit: "ops-manager-cloudfoundry"
+      on_error:
+        put: "deploy-status"
+        params:
+          state: "error"
+          commit: "ops-manager-cloudfoundry"
+      on_abort:
+        put: "deploy-status"
+        params:
+          state: "error"
+          commit: "ops-manager-cloudfoundry"
+          description: aborted
+  - put: "deploy-status"
+    params:
+      state: "success"
+      commit: "ops-manager-cloudfoundry"
 
 - name: smoke-tests
   serial: true
@@ -186,12 +260,36 @@ jobs:
     - get: ops-manager-cloudfoundry
       trigger: true
       passed: [ deploy-tile ]
+  - put: "test-status"
+    params:
+      state: "pending"
+      commit: "ops-manager-cloudfoundry"
   - task: smoke-tests
     file: ops-manager-cloudfoundry/ci/tasks/smoke-tests/task.yml
     params:
       PCF_URL: ((pcf-url))
       PCF_USERNAME: ((pcf-username))
       PCF_PASSWORD: ((pcf-password))
+    on_failure:
+      put: "test-status"
+      params:
+        state: "failure"
+        commit: "ops-manager-cloudfoundry"
+    on_error:
+      put: "test-status"
+      params:
+        state: "error"
+        commit: "ops-manager-cloudfoundry"
+    on_abort:
+      put: "test-status"
+      params:
+        state: "error"
+        commit: "ops-manager-cloudfoundry"
+        description: aborted
+  - put: "test-status"
+    params:
+      state: "success"
+      commit: "ops-manager-cloudfoundry"
 
 - name: shipit
   serial: true


### PR DESCRIPTION
This PR will allow us to see when a commit causes problems while building, deploying or testing in CI.
A new field is needed in `creds.yml`: `repo-github-token: ...`, and the token itself can be generated [on this GitHub settings page](https://github.com/settings/tokens).