### PR TITLE
Simplify tile.yml editing scripts

### DIFF
--- a/tile/tile.yml
+++ b/tile/tile.yml
@@ -344,7 +344,7 @@ runtime_configs:
     runtime_config:
       releases:
         - name: mongodb
-          version: 1.0.33
+          version: changeme
         - name: bpm
           version: 1.1.1
       addons:
@@ -384,7 +384,7 @@ runtime_configs:
     runtime_config:
       releases:
         - name: mongodb
-          version: 1.0.33
+          version: changeme
       addons:
         - name: mongodb-dns-aliases
           include:
@@ -425,7 +425,7 @@ packages:
     path: resources/syslog-migration-11.1.1.tgz
   - name: mongodb
     type: bosh-release
-    path: resources/mongodb-1.0.33.tgz
+    path: changeme
     jobs:
       - name: mongodb_broker
         label: MongoDB-ODB
@@ -514,7 +514,7 @@ packages:
           service_deployment:
             releases:
               - name: mongodb
-                version: 1.0.33
+                version: changeme
                 jobs:
                   - mongod_node
                   - mongodb_config_agent


### PR DESCRIPTION
This PR removes hard-coded versions from tile.yml, instead using jq to find and replace mongodb version and path.