### PR TITLE
Add iface checks to fix issues with upgrade from old versions

### DIFF
--- a/src/mongodb-config-agent/vendor/mongodb-service-adapter/adapter/manifest.go
+++ b/src/mongodb-config-agent/vendor/mongodb-service-adapter/adapter/manifest.go
@@ -416,7 +416,10 @@ func mongoPlanProperties(manifest bosh.BoshManifest) map[interface{}]interface{}
 
 func passwordForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["admin_password"].(string)
+		pass, ok := previousManifestProperties["admin_password"].(string)
+		if ok {
+			return pass
+		}
 	}
 
 	return GenerateString(20, true)
@@ -424,7 +427,10 @@ func passwordForMongoServer(previousManifestProperties map[interface{}]interface
 
 func idForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["id"].(string)
+		id, ok := previousManifestProperties["id"].(string)
+		if ok {
+			return id
+		}
 	}
 
 	return GenerateString(8, true)
@@ -432,7 +438,10 @@ func idForMongoServer(previousManifestProperties map[interface{}]interface{}) st
 
 func authKeyForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["auth_key"].(string)
+		key, ok := previousManifestProperties["auth_key"].(string)
+		if ok {
+			return key
+		}
 	}
 
 	return GenerateString(8, false)
@@ -448,11 +457,11 @@ func groupForMongoServer(
 	name := ""
 	orgID := ""
 	if p, found := arbitraryParams["projectName"]; found {
-		name = p.(string)
+		name, _ = p.(string)
 	}
 
 	if p, found := arbitraryParams["orgId"]; found {
-		orgID = p.(string)
+		orgID, _ = p.(string)
 	}
 
 	// TODO: investigate the use of tags

--- a/src/mongodb-service-adapter/adapter/manifest.go
+++ b/src/mongodb-service-adapter/adapter/manifest.go
@@ -416,7 +416,10 @@ func mongoPlanProperties(manifest bosh.BoshManifest) map[interface{}]interface{}
 
 func passwordForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["admin_password"].(string)
+		pass, ok := previousManifestProperties["admin_password"].(string)
+		if ok {
+			return pass
+		}
 	}
 
 	return GenerateString(20, true)
@@ -424,7 +427,10 @@ func passwordForMongoServer(previousManifestProperties map[interface{}]interface
 
 func idForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["id"].(string)
+		id, ok := previousManifestProperties["id"].(string)
+		if ok {
+			return id
+		}
 	}
 
 	return GenerateString(8, true)
@@ -432,7 +438,10 @@ func idForMongoServer(previousManifestProperties map[interface{}]interface{}) st
 
 func authKeyForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["auth_key"].(string)
+		key, ok := previousManifestProperties["auth_key"].(string)
+		if ok {
+			return key
+		}
 	}
 
 	return GenerateString(8, false)
@@ -448,11 +457,11 @@ func groupForMongoServer(
 	name := ""
 	orgID := ""
 	if p, found := arbitraryParams["projectName"]; found {
-		name = p.(string)
+		name, _ = p.(string)
 	}
 
 	if p, found := arbitraryParams["orgId"]; found {
-		orgID = p.(string)
+		orgID, _ = p.(string)
 	}
 
 	// TODO: investigate the use of tags

--- a/src/mongodb-service-adapter/go.sum
+++ b/src/mongodb-service-adapter/go.sum
@@ -62,6 +62,7 @@ github.com/pivotal-cf/brokerapi/v7 v7.0.0/go.mod h1:mdav81DVbnr6PSpqm+iATzHO4OUx
 github.com/pivotal-cf/on-demand-services-sdk v0.35.0 h1:xmyOFy92iKcO445XC3Mq9j//qsek/E3fGT94I1FPd4I=
 github.com/pivotal-cf/on-demand-services-sdk v0.35.0/go.mod h1:k0+f7kRxEPcg8qSS/s6IXOGRg9x8b5ER8HUtpN6V7/8=
 github.com/pivotal-cf/on-demand-services-sdk v0.37.0 h1:Cf29dNGbL/+Gzpfyb4HU/42Og8/vzh2FUjzm/UfpkuY=
+github.com/pivotal-cf/on-demand-services-sdk v0.38.0 h1:dDtM2d0mQP51hQ7S6toCeTuSWEm19K9t8STWurMhIfc=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/src/smoke-tests/vendor/mongodb-service-adapter/adapter/manifest.go
+++ b/src/smoke-tests/vendor/mongodb-service-adapter/adapter/manifest.go
@@ -416,7 +416,10 @@ func mongoPlanProperties(manifest bosh.BoshManifest) map[interface{}]interface{}
 
 func passwordForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["admin_password"].(string)
+		pass, ok := previousManifestProperties["admin_password"].(string)
+		if ok {
+			return pass
+		}
 	}
 
 	return GenerateString(20, true)
@@ -424,7 +427,10 @@ func passwordForMongoServer(previousManifestProperties map[interface{}]interface
 
 func idForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["id"].(string)
+		id, ok := previousManifestProperties["id"].(string)
+		if ok {
+			return id
+		}
 	}
 
 	return GenerateString(8, true)
@@ -432,7 +438,10 @@ func idForMongoServer(previousManifestProperties map[interface{}]interface{}) st
 
 func authKeyForMongoServer(previousManifestProperties map[interface{}]interface{}) string {
 	if previousManifestProperties != nil {
-		return previousManifestProperties["auth_key"].(string)
+		key, ok := previousManifestProperties["auth_key"].(string)
+		if ok {
+			return key
+		}
 	}
 
 	return GenerateString(8, false)
@@ -448,11 +457,11 @@ func groupForMongoServer(
 	name := ""
 	orgID := ""
 	if p, found := arbitraryParams["projectName"]; found {
-		name = p.(string)
+		name, _ = p.(string)
 	}
 
 	if p, found := arbitraryParams["orgId"]; found {
-		orgID = p.(string)
+		orgID, _ = p.(string)
 	}
 
 	// TODO: investigate the use of tags


### PR DESCRIPTION
Post-1.2 installations will not create invalid IDs, but 1.1 and older versions will. This is a proposal to discard all malformed info and re-generate it using the new algorithm.

Should fix PE's current issue with upgrade; possibly related to other occasional failures.