### PR TITLE
Rework connection string generation (not critical)

### DIFF
--- a/fixvendor.sh
+++ b/fixvendor.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -e
+
+for dir in src/{smoke-tests,mongodb-{config-agent,service-adapter}}; do
+    pushd $dir
+    echo "Fixing vendor in $dir..."
+    go mod vendor
+    popd
+done

--- a/src/mongodb-config-agent/vendor/mongodb-service-adapter/adapter/binding.go
+++ b/src/mongodb-config-agent/vendor/mongodb-service-adapter/adapter/binding.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
@@ -73,16 +74,6 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 		servers = ToEndpointList(hosts)
 	}
 
-	sslOption := ""
-	if ssl {
-		sslOption = "&ssl=true"
-	}
-	replicaSetName := ""
-	if plan == PlanReplicaSet {
-		replicaSetName = "&replicaSet=pcf_repl"
-	}
-	connectionOptions := []string{sslOption, replicaSetName}
-
 	session, err := GetWithCredentials(servers, adminPassword, ssl)
 	if err != nil {
 		return serviceadapter.Binding{}, err
@@ -111,13 +102,22 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 		return serviceadapter.Binding{}, err
 	}
 
-	url := fmt.Sprintf("mongodb://%s:%s@%s/%s?authSource=admin%s",
-		username,
-		password,
-		strings.Join(servers, ","),
-		defaultDB,
-		strings.Join(connectionOptions, ""),
-	)
+	connectionOpts := url.Values{}
+	connectionOpts.Add("authSource", adminDB)
+	if ssl {
+		connectionOpts.Add("ssl", "true")
+	}
+	if plan == PlanReplicaSet {
+		connectionOpts.Add("replicaSet", "pcf_repl")
+	}
+
+	url := url.URL{
+		Scheme:   "mongodb",
+		Host:     strings.Join(servers, ","),
+		User:     url.UserPassword(username, password),
+		Path:     defaultDB,
+		RawQuery: connectionOpts.Encode(),
+	}
 
 	return serviceadapter.Binding{
 		Credentials: map[string]interface{}{
@@ -126,7 +126,7 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 			"database": defaultDB,
 			"servers":  servers,
 			"ssl":      ssl,
-			"uri":      url,
+			"uri":      url.String(),
 		},
 	}, nil
 }

--- a/src/mongodb-service-adapter/adapter/binding.go
+++ b/src/mongodb-service-adapter/adapter/binding.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
@@ -73,16 +74,6 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 		servers = ToEndpointList(hosts)
 	}
 
-	sslOption := ""
-	if ssl {
-		sslOption = "&ssl=true"
-	}
-	replicaSetName := ""
-	if plan == PlanReplicaSet {
-		replicaSetName = "&replicaSet=pcf_repl"
-	}
-	connectionOptions := []string{sslOption, replicaSetName}
-
 	session, err := GetWithCredentials(servers, adminPassword, ssl)
 	if err != nil {
 		return serviceadapter.Binding{}, err
@@ -111,13 +102,22 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 		return serviceadapter.Binding{}, err
 	}
 
-	url := fmt.Sprintf("mongodb://%s:%s@%s/%s?authSource=admin%s",
-		username,
-		password,
-		strings.Join(servers, ","),
-		defaultDB,
-		strings.Join(connectionOptions, ""),
-	)
+	connectionOpts := url.Values{}
+	connectionOpts.Add("authSource", adminDB)
+	if ssl {
+		connectionOpts.Add("ssl", "true")
+	}
+	if plan == PlanReplicaSet {
+		connectionOpts.Add("replicaSet", "pcf_repl")
+	}
+
+	url := url.URL{
+		Scheme:   "mongodb",
+		Host:     strings.Join(servers, ","),
+		User:     url.UserPassword(username, password),
+		Path:     defaultDB,
+		RawQuery: connectionOpts.Encode(),
+	}
 
 	return serviceadapter.Binding{
 		Credentials: map[string]interface{}{
@@ -126,7 +126,7 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 			"database": defaultDB,
 			"servers":  servers,
 			"ssl":      ssl,
-			"uri":      url,
+			"uri":      url.String(),
 		},
 	}, nil
 }

--- a/src/smoke-tests/vendor/mongodb-service-adapter/adapter/binding.go
+++ b/src/smoke-tests/vendor/mongodb-service-adapter/adapter/binding.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log"
 	"net"
+	"net/url"
 	"strings"
 
 	"github.com/pivotal-cf/on-demand-services-sdk/serviceadapter"
@@ -73,16 +74,6 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 		servers = ToEndpointList(hosts)
 	}
 
-	sslOption := ""
-	if ssl {
-		sslOption = "&ssl=true"
-	}
-	replicaSetName := ""
-	if plan == PlanReplicaSet {
-		replicaSetName = "&replicaSet=pcf_repl"
-	}
-	connectionOptions := []string{sslOption, replicaSetName}
-
 	session, err := GetWithCredentials(servers, adminPassword, ssl)
 	if err != nil {
 		return serviceadapter.Binding{}, err
@@ -111,13 +102,22 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 		return serviceadapter.Binding{}, err
 	}
 
-	url := fmt.Sprintf("mongodb://%s:%s@%s/%s?authSource=admin%s",
-		username,
-		password,
-		strings.Join(servers, ","),
-		defaultDB,
-		strings.Join(connectionOptions, ""),
-	)
+	connectionOpts := url.Values{}
+	connectionOpts.Add("authSource", adminDB)
+	if ssl {
+		connectionOpts.Add("ssl", "true")
+	}
+	if plan == PlanReplicaSet {
+		connectionOpts.Add("replicaSet", "pcf_repl")
+	}
+
+	url := url.URL{
+		Scheme:   "mongodb",
+		Host:     strings.Join(servers, ","),
+		User:     url.UserPassword(username, password),
+		Path:     defaultDB,
+		RawQuery: connectionOpts.Encode(),
+	}
 
 	return serviceadapter.Binding{
 		Credentials: map[string]interface{}{
@@ -126,7 +126,7 @@ func (b Binder) CreateBinding(params serviceadapter.CreateBindingParams) (servic
 			"database": defaultDB,
 			"servers":  servers,
 			"ssl":      ssl,
-			"uri":      url,
+			"uri":      url.String(),
 		},
 	}, nil
 }


### PR DESCRIPTION
Use `url` package to generate MongoDB connection string instead of manually generating it